### PR TITLE
fix(): prettier config with eslint-prettier-config 8.0.0

### DIFF
--- a/src/beauty/index.ts
+++ b/src/beauty/index.ts
@@ -39,7 +39,7 @@ module.exports = function task() {
 	yaml('.eslintrc.yml')
 		.merge({
 			root: true,
-			extends: ['@typescord', 'plugin:prettier/recommended', 'prettier/@typescript-eslint'],
+			extends: ['@typescord', 'plugin'],
 			plugins: ['prettier'],
 			parserOptions: tsConfigExists ? { project: 'tsconfig.json' } : undefined,
 			rules: { 'prettier/prettier': 'error' },


### PR DESCRIPTION
New version of eslint-prettier-config (8.0.0) grouped "plugin:prettier/recommended" and "prettier/@typescript-eslint" in a single one to extend: "prettier".